### PR TITLE
Correctly use nr_bw to convert BW to actually bandwidth

### DIFF
--- a/scripts/modemstatus_parse.sh
+++ b/scripts/modemstatus_parse.sh
@@ -266,6 +266,7 @@ case $RAT in
 			CHANNEL=$(echo $QENG5 | cut -d, -f10)
 			LBAND=$(echo $QENG5 | cut -d, -f11)
 			BW=$(echo $QENG5 | cut -d, -f12)
+   			nr_bw
 			LBAND="n"$LBAND" (Bandwidth $BW MHz)"
 			RSCP=$(echo $QENG5 | cut -d, -f13)
 			ECIO=$(echo $QENG5 | cut -d, -f14)


### PR DESCRIPTION
Under NR5G, the bw marker is not correctly converted to actual bandwidth MHz. Use existing function to do what is already under NSA to do the same under SA